### PR TITLE
Include bash shell output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./
+        id: cygwin
         with:
           packages: curl,patch
       - name: Run shell
         run: |
           ls
           echo "hello"
-        shell: C:\cygwin64\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+        shell: ${{ steps.cygwin.outputs.bash }}

--- a/README.md
+++ b/README.md
@@ -10,12 +10,23 @@ with your windows-based workflows.
 # Usage
 
 Basic:
-
 ```yaml
 steps:
   - uses: secondlife/setup-cygwin@v1
     with:
-      packages: bash,curl
+      packages: patch,curl
+```
+
+Running a command in the cygwin shell:
+```yaml
+steps:
+  - uses: secondlife/setup-cygwin@v1
+    id: cygwin
+  - name: Run cygwin command
+    shell: ${{ steps.cygwin.outputs.bash }}
+    run: |
+      ls
+      echo "Hello!"
 ```
 
 For additional information about Cygwin see [https://www.cygwin.com/]()

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,7 @@
 name: 'Setup Cygwin'
 description: 'Install Cygwin'
-author: 'Linden Lab'
+author: 'Linden Research, Inc.'
+
 inputs:
   packages:
     description: 'Cygwin packages to install'
@@ -13,6 +14,12 @@ inputs:
   local-packages:
     description: 'Package download directory'
     default: 'C:\TEMP\cygwinpackages'
+
+outputs:
+  bash:
+    description: 'Cygwin shell'
+    value: ${{ inputs.root }}\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Make it simpler for people to use cygwin shells from their actions by exporting an output with location of cygwin's bash.