### PR TITLE
Remove invalid code owners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @secondlife/platform


### PR DESCRIPTION
The current CODEOWNERS file no longer refers to any valid team names. Let's remove the code owners file.